### PR TITLE
[zookeeper] Zookeeper with metrics enabled

### DIFF
--- a/charts/zookeeper/Chart.yaml
+++ b/charts/zookeeper/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.3
+version: 0.1.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/zookeeper/templates/statefulset.yaml
+++ b/charts/zookeeper/templates/statefulset.yaml
@@ -68,16 +68,20 @@ spec:
         args:
           - |
             /opt/radiantone/run.sh &
-            # check nc installed
-            if rpm -qa | grep -i nmap-ncat; then :; else
-              yum install -y nc;
-            fi
-            # check mntr
+            # wait until zookeeper starts
+            until nc -w 2 -z localhost 2181; do echo "Waiting for Zookeeper to start on port 2181";sleep 10; done;echo "Zookeeper is up"
+            # check mntr - this is needed for metrics collection
             if echo mntr | nc localhost 2181 | grep "not in the whitelist"; then
-              until nc -w 2 -z localhost 2181; do echo Waiting for zk -- 2181;sleep 10; done;echo \"zk is up!\"
-              echo "4lw.commands.whitelist=ruok,mntr" >> /opt/radiantone/rli-zookeeper-external/zookeeper/conf/zoo.cfg
+              # stop zookeeper
               /opt/radiantone/rli-zookeeper-external/bin/stop_zookeeper.sh
+              # add ruok and mntr to whitelist
+              echo "Adding ruok,mntr to whitelist"
+              echo "4lw.commands.whitelist=ruok,mntr" >> /opt/radiantone/rli-zookeeper-external/zookeeper/conf/zoo.cfg
+              # start zookeeper
               /opt/radiantone/run.sh
+            else
+              # tail the log file so the container does not exit
+              tail -F /opt/radiantone/rli-zookeeper-external/zookeeper/logs/zookeeper.log
             fi
 {{- else }}
         command: ["/bin/sh","-c"]


### PR DESCRIPTION
#### What this PR does / why we need it:
When metrics are enabled, mntr should be whitelisted. If the container restarts after mntr is whitelisted, it does not stay up as the process is sent to background. Added tail -f on log file to keep it in foreground. Also, removed the netcat install, as this will be installed in the image.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[fid]`)
