### PR TITLE
zookeeper-upgrade

### DIFF
--- a/charts/zookeeper/Chart.yaml
+++ b/charts/zookeeper/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.4
+version: 0.1.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/zookeeper/templates/fluentd-configmap.yaml
+++ b/charts/zookeeper/templates/fluentd-configmap.yaml
@@ -23,13 +23,13 @@ data:
             multiline_start_regexp /\d{4}-\d{1,2}-\d{1,2}/
         </parse>
     </source>
-    <filter vds_server.log>
+    <filter zookeeper.log>
         @type record_transformer
         <record>
         hostname ${hostname}
         </record>
     </filter>
-    <match vds_server.log>
+    <match zookeeper.log>
         @type {{ .Values.metrics.fluentd.elasticSearchType }}
         host ELASTICSEARCH_HOST
         port ELASTICSEARCH_PORT

--- a/charts/zookeeper/templates/fluentd-configmap.yaml
+++ b/charts/zookeeper/templates/fluentd-configmap.yaml
@@ -1,0 +1,40 @@
+{{- if eq .Values.metrics.fluentd.enabled true }}
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: fluentd-config
+  labels:
+    app: {{ template "zookeeper.fullname" . }}
+    chart: "{{ template "zookeeper.chart" . }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+data:
+  fluent.conf: |
+    <source>
+        @type tail
+        read_from_head true
+        path /opt/radiantone/rli-zookeeper-external/zookeeper/logs/zookeeper.log
+        pos_file /var/log/zookeeper/zookeeperlog.pos
+        tag zookeeper.log
+        <parse>
+            @type multiline_grok
+            grok_pattern %{TIMESTAMP_ISO8601:timestamp} \[myid:%{NUMBER:zk_id}\] - %{WORD:log_level} \[%{GREEDYDATA:thread_name}\] - %{GREEDYDATA:message}
+            multiline_start_regexp /\d{4}-\d{1,2}-\d{1,2}/
+        </parse>
+    </source>
+    <filter vds_server.log>
+        @type record_transformer
+        <record>
+        hostname ${hostname}
+        </record>
+    </filter>
+    <match vds_server.log>
+        @type {{ .Values.metrics.fluentd.elasticSearchType }}
+        host ELASTICSEARCH_HOST
+        port ELASTICSEARCH_PORT
+        logstash_format true
+        logstash_prefix zookeeper.log
+    </match>
+
+{{- end }}

--- a/charts/zookeeper/templates/fluentd-configmap.yaml
+++ b/charts/zookeeper/templates/fluentd-configmap.yaml
@@ -1,5 +1,4 @@
 {{- if eq .Values.metrics.fluentd.enabled true }}
-
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -36,5 +35,4 @@ data:
         logstash_format true
         logstash_prefix zookeeper.log
     </match>
-
 {{- end }}

--- a/charts/zookeeper/templates/ingress.yaml
+++ b/charts/zookeeper/templates/ingress.yaml
@@ -1,7 +1,9 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "zookeeper.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1beta1
 {{- else -}}
 apiVersion: extensions/v1beta1

--- a/charts/zookeeper/templates/statefulset.yaml
+++ b/charts/zookeeper/templates/statefulset.yaml
@@ -104,6 +104,10 @@ spec:
         volumeMounts:
         - name: zk-pvc
           mountPath: /opt/radiantone/rli-zookeeper-external
+{{- if eq .Values.metrics.fluentd.enabled true }}
+        - name: fluentd-config-volume
+          mountPath: /fluentd/etc
+{{- end }}
         securityContext:
           runAsUser: 0
         env:
@@ -123,9 +127,11 @@ spec:
           value: {{ .Values.metrics.fluentd.configFile | quote }}
         - name: ELASTICSEARCH_HOST
           value: {{ .Values.metrics.fluentd.elasticSearchHost | quote }}
+        - name: ELASTICSEARCH_TYPE
+          value: {{ .Values.metrics.fluentd.elasticSearchType | default "elasticsearch" | quote }}
 {{- end }}
-{{- end }}    
-{{- end }} 
+{{- end }}
+{{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -167,4 +173,9 @@ spec:
       volumes:
       - name: zk-pvc
         emptyDir: {}
+{{- end }}
+{{- if eq .Values.metrics.fluentd.enabled true }}
+      - name: fluentd-config-volume
+        configMap:
+          name: fluentd-config
 {{- end }}

--- a/charts/zookeeper/values.yaml
+++ b/charts/zookeeper/values.yaml
@@ -111,7 +111,7 @@ metrics:
   pushMode: true
   pushGateway: http://prometheus-pushgateway:9091
   fluentd:
-    enabled: true
+    enabled: false
     configFile: /fluentd/etc/fluent.conf
     elasticSearchHost: elasticsearch-master
     elasticSearchType: elasticsearch

--- a/charts/zookeeper/values.yaml
+++ b/charts/zookeeper/values.yaml
@@ -114,6 +114,7 @@ metrics:
     enabled: true
     configFile: /fluentd/etc/fluent.conf
     elasticSearchHost: elasticsearch-master
+    elasticSearchType: elasticsearch
   livenessProbe:
     initialDelaySeconds: 60
     timeoutSeconds: 5


### PR DESCRIPTION
1. Modified the ingress.yaml versions
2. Added fluentd-configmap
3. Added opensearch support

#### What this PR does / why we need it:

THis PR has been created to update the existing zookeeper chart with api versions of ingress.yaml file to match the kubernetes cluster version. Also fluentd conf has now been enabled as a configmap and can be edited before apply or upgraded.
Support to push the logs from fluentd to opensearch also has been added through a " elasticsearchType " in the values.yaml file ( also need to provide a proper endpoint)

#### Which issue this PR fixes
ingress.yaml versions match to the kubernetes cluster versions
fluentd conf as a configmap
opensearch support

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ x ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ x ] Title of the PR starts with chart name (e.g. `[fid]`)
