### PR TITLE
fid hem-charts, update values.yaml

### DIFF
--- a/charts/common-services/Chart.yaml
+++ b/charts/common-services/Chart.yaml
@@ -75,3 +75,7 @@ dependencies:
   version: 0.24.0
   repository: https://fluent.github.io/helm-charts
   condition: fluent-bit.enabled
+- name: elasticsearch-curator
+  version: 3.2.3
+  repository: https://lebenitza.github.io/charts
+  condition: curator.enabled

--- a/charts/common-services/values.yaml
+++ b/charts/common-services/values.yaml
@@ -721,3 +721,223 @@ fluent-bit:
     - name: config
       mountPath: /fluent-bit/etc/custom_parsers.conf
       subPath: custom_parsers.conf
+
+
+curator:
+  enabled: false
+  cronjob:
+    # At 01:00 every day
+    schedule: "* * * * *"
+    annotations: {}
+    labels: {}
+    concurrencyPolicy: ""
+    failedJobsHistoryLimit: ""
+    successfulJobsHistoryLimit: ""
+    jobRestartPolicy: Never
+    startingDeadlineSeconds: ""
+  image:
+    repository: bitnami/elasticsearch-curator-archived
+    tag: 5.8.4-debian-10-r253
+    pullPolicy: Always
+  dryrun: false
+  nodeSelector:
+    tenantname: duploservices-rli-use2-svc
+  configMaps:
+    # Delete indices older than 7 days
+    action_file_yml: |-
+      ---
+      actions:
+        1:
+          action: delete_indices
+          description: "Delete indices older than 15 days"
+          options:
+            timeout_override:
+            continue_if_exception: False
+            disable_action: False
+            ignore_empty_list: True
+          filters:
+              - filtertype: pattern
+                kind: prefix
+                value: vds_server
+                exclude: False
+              - filtertype: age
+                source: name
+                timestring: '%Y.%m.%d'
+                unit: days
+                unit_count: 15
+                direction: older
+        2:
+          action: delete_indices
+          description: "Delete indices older than 7 days"
+          options:
+            timeout_override:
+            continue_if_exception: False
+            disable_action: False
+            ignore_empty_list: True
+          filters:
+              - filtertype: pattern
+                kind: prefix
+                value: admin_rest_api_access.log
+                exclude: False
+              - filtertype: age
+                source: name
+                timestring: '%Y.%m.%d'
+                unit: days
+                unit_count: 7
+                direction: older
+        3:
+          action: delete_indices
+          description: "Delete indices older than 7 days"
+          options:
+            timeout_override:
+            continue_if_exception: False
+            disable_action: False
+            ignore_empty_list: True
+          filters:
+              - filtertype: pattern
+                kind: prefix
+                value: adap_access.log
+                exclude: False
+              - filtertype: age
+                source: name
+                timestring: '%Y.%m.%d'
+                unit: days
+                unit_count: 7
+                direction: older
+        4:
+          action: delete_indices
+          description: "Delete indices older than 7 days"
+          options:
+            timeout_override:
+            continue_if_exception: False
+            disable_action: False
+            ignore_empty_list: True
+          filters:
+              - filtertype: pattern
+                kind: prefix
+                value: vds_events.log
+                exclude: False
+              - filtertype: age
+                source: name
+                timestring: '%Y.%m.%d'
+                unit: days
+                unit_count: 7
+                direction: older
+        5:
+          action: delete_indices
+          description: "Delete indices older than 7 days"
+          options:
+            timeout_override:
+            continue_if_exception: False
+            disable_action: False
+            ignore_empty_list: True
+          filters:
+              - filtertype: pattern
+                kind: prefix
+                value: alerts.log
+                exclude: False
+              - filtertype: age
+                source: name
+                timestring: '%Y.%m.%d'
+                unit: days
+                unit_count: 7
+                direction: older
+        6:
+          action: delete_indices
+          description: "Delete indices older than 7 days"
+          options:
+            timeout_override:
+            continue_if_exception: False
+            disable_action: False
+            ignore_empty_list: True
+          filters:
+              - filtertype: pattern
+                kind: prefix
+                value: sync_engine.log
+                exclude: False
+              - filtertype: age
+                source: name
+                timestring: '%Y.%m.%d'
+                unit: days
+                unit_count: 7
+                direction: older
+        7:
+          action: delete_indices
+          description: "Delete indices older than 7 days"
+          options:
+            timeout_override:
+            continue_if_exception: False
+            disable_action: False
+            ignore_empty_list: True
+          filters:
+              - filtertype: pattern
+                kind: prefix
+                value: web_access.log
+                exclude: False
+              - filtertype: age
+                source: name
+                timestring: '%Y.%m.%d'
+                unit: days
+                unit_count: 7
+                direction: older
+        8:
+          action: delete_indices
+          description: "Delete indices older than 7 days"
+          options:
+            timeout_override:
+            continue_if_exception: False
+            disable_action: False
+            ignore_empty_list: True
+          filters:
+              - filtertype: pattern
+                kind: prefix
+                value: web.log
+                exclude: False
+              - filtertype: age
+                source: name
+                timestring: '%Y.%m.%d'
+                unit: days
+                unit_count: 7
+                direction: older
+        9:
+          action: delete_indices
+          description: "Delete indices older than 7 days"
+          options:
+            timeout_override:
+            continue_if_exception: False
+            disable_action: False
+            ignore_empty_list: True
+          filters:
+              - filtertype: pattern
+                kind: prefix
+                value: periodiccache.log
+                exclude: False
+              - filtertype: age
+                source: name
+                timestring: '%Y.%m.%d'
+                unit: days
+                unit_count: 7
+                direction: older
+
+    # Having config_yaml WILL override the other config
+    config_yml: |-
+      ---
+      client:
+        hosts:
+          - elasticsearch-master
+        port: 9200
+        url_prefix:
+        use_ssl: False
+        certificate:
+        client_cert:
+        client_key:
+        ssl_no_validate: True
+        http_auth:
+        timeout: 300
+        master_only: False
+      logging:
+        loglevel: INFO
+        logfile:
+        logformat: default
+        blacklist: ['elasticsearch', 'urllib3']
+

--- a/charts/fid/Chart.yaml
+++ b/charts/fid/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 1.0.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/fid/values.yaml
+++ b/charts/fid/values.yaml
@@ -161,7 +161,7 @@ metrics:
   pushMetricCron: "* * * * *"
   fluentd:
     enabled: false
-    configFile: /fluentd/etc/fluent.conf
+    configFile: /tmp/fluent.conf
     elasticSearchHost: elasticsearch-master
     elasticSearchType: elasticsearch
   livenessProbe:


### PR DESCRIPTION
Update the FID values.yaml to reflect the updated fluentd.conf location

#### What this PR does / why we need it:

Updated values.yaml file to reflect the correct path to the fluentd conf file /tmp/fluent.conf

#### Which issue this PR fixes

Fixes the issue with fid-exporter not being able to find the elasticsearch host, since the configmap mounted files are read-only by default

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x ] Chart Version bumped
- [ x] Variables are documented in the README.md
- [ x] Title of the PR starts with chart name (e.g. `[fid]`)
