### PR TITLE
CT-677 Add basic metrics for IA

### DIFF
--- a/charts/common-services/Chart.yaml
+++ b/charts/common-services/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.5
+version: 1.0.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/common-services/dashboards/ia-service-status-dashboard.json
+++ b/charts/common-services/dashboards/ia-service-status-dashboard.json
@@ -1,0 +1,764 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "dark-red",
+                "value": 0
+              },
+              {
+                "color": "semi-dark-red",
+                "value": 10
+              },
+              {
+                "color": "red",
+                "value": 20
+              },
+              {
+                "color": "super-light-orange",
+                "value": 30
+              },
+              {
+                "color": "light-orange",
+                "value": 40
+              },
+              {
+                "color": "orange",
+                "value": 50
+              },
+              {
+                "color": "light-yellow",
+                "value": 60
+              },
+              {
+                "color": "yellow",
+                "value": 70
+              },
+              {
+                "color": "super-light-green",
+                "value": 80
+              },
+              {
+                "color": "light-green",
+                "value": 90
+              },
+              {
+                "color": "green",
+                "value": 100
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 5,
+        "x": 0,
+        "y": 0
+      },
+      "id": 6,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.1.6",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "(sum(count_over_time(ia_database_pg_status{clustername=\"$clustername\"}[$__range])) - sum(sum_over_time(ia_database_pg_status{clustername=\"$clustername\"}[$__range])))/sum(count_over_time(ia_database_pg_status{clustername=\"$clustername\"}[$__range])) * 100",
+          "legendFormat": "Database Availability",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Database Availability",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "dark-red",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 10
+              },
+              {
+                "color": "super-light-orange",
+                "value": 20
+              },
+              {
+                "color": "light-orange",
+                "value": 30
+              },
+              {
+                "color": "orange",
+                "value": 40
+              },
+              {
+                "color": "super-light-yellow",
+                "value": 50
+              },
+              {
+                "color": "light-yellow",
+                "value": 60
+              },
+              {
+                "color": "yellow",
+                "value": 70
+              },
+              {
+                "color": "super-light-green",
+                "value": 80
+              },
+              {
+                "color": "light-green",
+                "value": 90
+              },
+              {
+                "color": "green",
+                "value": 100
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 5,
+        "x": 6,
+        "y": 0
+      },
+      "id": 7,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.1.6",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "(sum(count_over_time(ia_extractor_http_status{clustername=\"$clustername\"}[$__range])) - sum(sum_over_time(ia_extractor_http_status{clustername=\"$clustername\"}[$__range])))/sum(count_over_time(ia_extractor_http_status{clustername=\"$clustername\"}[$__range])) * 100",
+          "legendFormat": "Extractor Availability",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Extractor Availability",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "dark-red",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 10
+              },
+              {
+                "color": "super-light-orange",
+                "value": 20
+              },
+              {
+                "color": "light-orange",
+                "value": 30
+              },
+              {
+                "color": "orange",
+                "value": 40
+              },
+              {
+                "color": "super-light-yellow",
+                "value": 50
+              },
+              {
+                "color": "light-yellow",
+                "value": 60
+              },
+              {
+                "color": "yellow",
+                "value": 70
+              },
+              {
+                "color": "super-light-green",
+                "value": 80
+              },
+              {
+                "color": "light-green",
+                "value": 90
+              },
+              {
+                "color": "green",
+                "value": 100
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 3,
+        "x": 12,
+        "y": 0
+      },
+      "id": 8,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.1.6",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "(sum(count_over_time(app_config_http_status{clustername=\"$clustername\"}[$__range])) - sum(sum_over_time(app_config_http_status{clustername=\"$clustername\"}[$__range])))/sum(count_over_time(app_config_http_status{clustername=\"$clustername\"}[$__range])) * 100",
+          "legendFormat": "Configuration Availability",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Configuration Availability",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "dark-red",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 10
+              },
+              {
+                "color": "super-light-orange",
+                "value": 20
+              },
+              {
+                "color": "light-orange",
+                "value": 30
+              },
+              {
+                "color": "orange",
+                "value": 40
+              },
+              {
+                "color": "super-light-yellow",
+                "value": 50
+              },
+              {
+                "color": "light-yellow",
+                "value": 60
+              },
+              {
+                "color": "yellow",
+                "value": 70
+              },
+              {
+                "color": "super-light-green",
+                "value": 80
+              },
+              {
+                "color": "light-green",
+                "value": 90
+              },
+              {
+                "color": "green",
+                "value": 100
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 3,
+        "x": 16,
+        "y": 0
+      },
+      "id": 9,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.1.6",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "(sum(count_over_time(ia_controller_http_status{clustername=\"$clustername\"}[$__range])) - sum(sum_over_time(ia_controller_http_status{clustername=\"$clustername\"}[$__range])))/sum(count_over_time(ia_controller_http_status{clustername=\"$clustername\"}[$__range])) * 100",
+          "legendFormat": "Controller Availability",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Controller Availability",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "dark-red",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 10
+              },
+              {
+                "color": "super-light-orange",
+                "value": 20
+              },
+              {
+                "color": "light-orange",
+                "value": 30
+              },
+              {
+                "color": "orange",
+                "value": 40
+              },
+              {
+                "color": "super-light-yellow",
+                "value": 50
+              },
+              {
+                "color": "light-yellow",
+                "value": 60
+              },
+              {
+                "color": "yellow",
+                "value": 70
+              },
+              {
+                "color": "super-light-green",
+                "value": 80
+              },
+              {
+                "color": "light-green",
+                "value": 90
+              },
+              {
+                "color": "green",
+                "value": 100
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 3,
+        "x": 20,
+        "y": 0
+      },
+      "id": 10,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.1.6",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "(sum(count_over_time(ia_portal_http_status{clustername=\"$clustername\"}[$__range])) - sum(sum_over_time(ia_portal_http_status{clustername=\"$clustername\"}[$__range])))/sum(count_over_time(ia_portal_http_status{clustername=\"$clustername\"}[$__range])) * 100",
+          "legendFormat": "Portal Availability",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Portal Availability",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "fillOpacity": 70,
+            "lineWidth": 1
+          },
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "index": 0,
+                  "text": "UP"
+                },
+                "1": {
+                  "index": 1,
+                  "text": "DOWN"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 7
+      },
+      "id": 2,
+      "interval": "30s",
+      "maxDataPoints": 100,
+      "options": {
+        "colWidth": 0.9,
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "rowHeight": 0.9,
+        "showValue": "never",
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum(ia_database_pg_status{clustername=\"$clustername\"})",
+          "interval": "",
+          "legendFormat": "Database Service",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum(ia_extractor_http_status{clustername=\"$clustername\"})",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Extractor",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum(app_config_http_status{clustername=\"$clustername\"})",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Configuration",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(ia_controller_http_status{clustername=\"$clustername\"})",
+          "hide": false,
+          "legendFormat": "Controller",
+          "range": true,
+          "refId": "E"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(ia_portal_http_status{clustername=\"$clustername\"})",
+          "hide": false,
+          "legendFormat": "Portal",
+          "range": true,
+          "refId": "D"
+        }
+      ],
+      "title": "Identity Analytics Service Status",
+      "type": "status-history"
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 37,
+  "style": "dark",
+  "tags": [
+    "identity-analytics",
+    "radiantone"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(ia_config_http_status,clustername)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "environment",
+        "multi": false,
+        "name": "clustername",
+        "options": [],
+        "query": {
+          "query": "label_values(ia_config_http_status,clustername)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "Prometheus",
+          "value": "Prometheus"
+        },
+        "hide": 2,
+        "includeAll": false,
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-30m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Identity Analytics Service Status",
+  "uid": "IAJsbWQzU4k_JMC",
+  "version": 1,
+  "weekStart": ""
+}

--- a/charts/common-services/templates/grafana-dashboards.yaml
+++ b/charts/common-services/templates/grafana-dashboards.yaml
@@ -36,5 +36,15 @@ metadata:
 data:
 {{ (.Files.Glob "dashboards/service-status-dashboard.json").AsConfig | indent 2 }}
 
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ia-service-status-dashboard
+  labels:
+    grafana_dashboard: "1"
+data:
+{{ (.Files.Glob "dashboards/ia-service-status-dashboard.json").AsConfig | indent 2 }}
+
 
 {{- end }}

--- a/charts/common-services/values.yaml
+++ b/charts/common-services/values.yaml
@@ -182,11 +182,22 @@ grafana:
         editable: true
         options:
           path: /var/lib/grafana/dashboards/service-status
+      - name: 'ia-service-status'
+        orgId: 1
+        folder: ''
+        type: file
+        disableDeletion: false
+        updateIntervalSeconds: 10
+        allowUiUpdates: true
+        editable: true
+        options:
+          path: /var/lib/grafana/dashboards/ia-service-status
   dashboardsConfigMaps:
     fid: "fid-dashboard"
     zookeeper: "zookeeper-dashboard"
     elasticsearch: "audit-logs-elastic-dashboard"
     service-status: "service-status-dashboard"
+    ia-service-status: "ia-service-status-dashboard"
 
 elasticsearch:
   enabled: true

--- a/charts/fid/templates/migration-cronjob.yaml
+++ b/charts/fid/templates/migration-cronjob.yaml
@@ -31,7 +31,7 @@ spec:
                 chmod +x ./kubectl;
                 mv ./kubectl /usr/local/bin;
                 kubectl get po -n {{ .Release.Namespace }};
-                kubectl exec -it fid-0 -n {{ .Release.Namespace }} -- bash -c "./migrate.sh generate-migration-plan ;
+                kubectl exec -it fid-0 -n {{ .Release.Namespace }} -- bash -c "/opt/radiantone/vds/bin/advanced/migrate.sh generate-migration-plan" ;
                 kubectl exec -it fid-0 -n {{ .Release.Namespace }} -- bash -c "./migrate.sh export $EXPORT_FILE_NAME" ;
                 kubectl exec -it fid-0 -n {{ .Release.Namespace }} -- bash -c "ls -ltr /opt/radiantone/vds/work/" ;
                 kubectl -n {{ .Release.Namespace }} cp fid-0:/opt/radiantone/vds/work/$EXPORT_FILE_NAME $EXPORT_FILE_NAME ;

--- a/charts/fid/templates/statefulset.yaml
+++ b/charts/fid/templates/statefulset.yaml
@@ -287,11 +287,13 @@ spec:
               export CLUSTER=join;
             fi;
 
+            # Run the statrtup script
+            ./run.sh
+
             {{- if .Values.postInstall.enabled }}
-              ./run.sh
               ## if CURRENT_BUILDID="" it is a new install
-              if [ $CURRENT_BUILDID = "" ]; then
-                echo "Running post install script"
+              if [ "$CURRENT_BUILDID" = "" ]; then
+                echo ">> Running post install script"
                 {{- if .Values.postInstall.leaderOnly }}
                 if [ $HOSTNAME = {{ template "fid.fullname" . }}-0 ]; then
                   {{ .Values.postInstall.script | nindent 14 }}
@@ -300,14 +302,10 @@ spec:
                   {{ .Values.postInstall.script | nindent 14 }}
                 {{- end }}
               fi;
-              tail -f /dev/null
-            {{- else }}
-              ./run.sh fg
             {{- end }}
 
             {{- if .Values.postStart.enabled }}
-              ./run.sh
-              echo "Running post startup script"
+              echo ">> Running post startup script"
               {{- if .Values.postStart.leaderOnly }}
               if [ $HOSTNAME = {{ template "fid.fullname" . }}-0 ]; then
                 {{ .Values.postStart.script | nindent 14 }}
@@ -315,11 +313,10 @@ spec:
               {{- else }}
                 {{ .Values.postStart.script | nindent 14 }}
               {{- end }}
-              tail -f /dev/null
-            {{- else }}
-              ./run.sh fg
             {{- end }}
-
+            
+            tail -f /dev/null
+            
 {{- end }}
 {{- if .Values.metrics.enabled }}
       - name: {{ .Chart.Name }}-exporter


### PR DESCRIPTION
#### What this PR does / why we need it:
The goal is to leverage the script exporter to allow Prometheus to scrap services metrics for Identity Analytics application.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[fid]`)
