### PR TITLE
chore(common-services): bump chart to 2.0.2 and cloudnative-pg to 0.28.0

### DIFF
--- a/charts/common-services/Chart.yaml
+++ b/charts/common-services/Chart.yaml
@@ -10,7 +10,7 @@ type: application
 # Chart Version
 # -------------
 # This version should be incremented following Semantic Versioning (https://semver.org/) whenever the chart's structure or templates change.
-version: 2.0.1
+version: 2.0.2
 
 # Application Version (Informational)
 # -----------------------------------
@@ -98,7 +98,7 @@ dependencies:
   condition: velero.enabled
 - name: cloudnative-pg
   repository: https://cloudnative-pg.github.io/charts
-  version: 0.27.1
+  version: 0.28.0
   condition: cloudnative-pg.enabled
 - name: velero-ui
   version: 0.x.x


### PR DESCRIPTION
#### What this PR does / why we need it:

Release **common-services** as **2.0.2** by bumping the **cloudnative-pg** Helm dependency to **0.28.0**, so the umbrella chart tracks the upstream chart (fixes and changes shipped by CloudNative-PG).
Changes in `Chart.yaml`:
- chart version: 2.0.1 → 2.0.2
- `cloudnative-pg` dependency: 0.27.1 → 0.28.0

#### Which issue this PR fixes
*(no linked issue — section intentionally left blank)*

#### Special notes for your reviewer:

- Scope is limited to chart metadata / dependencies; no new `values` keys in this PR.
- `charts/common-services/README.md` (badges, dependency table, “What’s New” section) is still out of sync with `Chart.yaml` (e.g. displayed chart version and CNPG version in the table). If the repo expects a regenerated README (often via `helm-docs`), please run it or note if README sync happens in another commit or at merge.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [  ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[fid]`)
